### PR TITLE
Update site links to thiago4go.github.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# novemberkilo.github.com
+# thiago4go.github.io
 my blog

--- a/about/index.html
+++ b/about/index.html
@@ -125,7 +125,7 @@
 <h3 id="the-site">The Site</h3>
 <p>This site is hosted on <a href="http://github.com">GitHub</a> using their
 <a href="http://github.com/blog/272-github-pages">Pages</a> feature.</p>
-<p>I got the inspiration for the site from <a href="http://www.novemberkilo.com/">The iNK blot</a> and
+<p>I got the inspiration for the site from <a href="https://thiago4go.github.io/">The iNK blot</a> and
 <p>It is created using the static site generator <a href="https://www.getzola.org/">zola</a>
 and uses the <a href="https://github.com/VersBinarii/hermit_zola">hermit_zola</a> theme.</p>
 <h3 id="license">License</h3>

--- a/robots.txt
+++ b/robots.txt
@@ -1,3 +1,3 @@
 User-agent: *
 Allow: /
-Sitemap: https://novemberkilo.com/sitemap.xml
+Sitemap: https://thiago4go.github.io/sitemap.xml

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,40 +1,40 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
-        <loc>https://novemberkilo.com/</loc>
+        <loc>https://thiago4go.github.io/</loc>
     </url>
     <url>
-        <loc>https://novemberkilo.com/about/</loc>
+        <loc>https://thiago4go.github.io/about/</loc>
     </url>
     <url>
-        <loc>https://novemberkilo.com/posts/</loc>
+        <loc>https://thiago4go.github.io/posts/</loc>
     </url>
     <url>
-        <loc>https://novemberkilo.com/posts/data-engineering-principles/</loc>
+        <loc>https://thiago4go.github.io/posts/data-engineering-principles/</loc>
         <lastmod>2020-05-25</lastmod>
     </url>
     <url>
-        <loc>https://novemberkilo.com/posts/json-finders/</loc>
+        <loc>https://thiago4go.github.io/posts/json-finders/</loc>
         <lastmod>2014-05-25</lastmod>
     </url>
     <url>
-        <loc>https://novemberkilo.com/posts/refactoring-with-applicative/</loc>
+        <loc>https://thiago4go.github.io/posts/refactoring-with-applicative/</loc>
         <lastmod>2018-05-27</lastmod>
     </url>
     <url>
-        <loc>https://novemberkilo.com/posts/scopes-for-empty-relationships/</loc>
+        <loc>https://thiago4go.github.io/posts/scopes-for-empty-relationships/</loc>
         <lastmod>2013-09-29</lastmod>
     </url>
     <url>
-        <loc>https://novemberkilo.com/tags/</loc>
+        <loc>https://thiago4go.github.io/tags/</loc>
     </url>
     <url>
-        <loc>https://novemberkilo.com/tags/blog/</loc>
+        <loc>https://thiago4go.github.io/tags/blog/</loc>
     </url>
     <url>
-        <loc>https://novemberkilo.com/tags/haskell/</loc>
+        <loc>https://thiago4go.github.io/tags/haskell/</loc>
     </url>
     <url>
-        <loc>https://novemberkilo.com/tags/refactoring/</loc>
+        <loc>https://thiago4go.github.io/tags/refactoring/</loc>
     </url>
 </urlset>

--- a/tags/blog/index.html
+++ b/tags/blog/index.html
@@ -6,21 +6,21 @@
   <meta itemprop="name" content="The iNK blot" />
   <meta itemprop="description" content="" />
 
-  <link rel="apple-touch-icon" sizes="180x180" href="https://novemberkilo.com/apple-touch-icon.png"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="https://novemberkilo.com/favicon-32x32.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://thiago4go.github.io/apple-touch-icon.png"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="https://thiago4go.github.io/favicon-32x32.png" />
   <link
     rel="icon"
     type="image/png"
     sizes="16x16"
-    href="https://novemberkilo.com/favicon-16x16.png"
+    href="https://thiago4go.github.io/favicon-16x16.png"
   />
   <link
     rel="shortcut icon"
-    href="https://novemberkilo.com/favicon.ico"
+    href="https://thiago4go.github.io/favicon.ico"
   />
   <link rel="stylesheet"
     href="https://fonts.googleapis.com/css?family=Inter">
-  <link rel="stylesheet" href="https://novemberkilo.com/style.css"/>
+  <link rel="stylesheet" href="https://thiago4go.github.io/style.css"/>
   <title>The iNK blot</title>
 
   <body id="page">
@@ -30,7 +30,7 @@
   <div class="hdr-wrapper section-inner">
     <div class="hdr-left">
       <div class="site-branding">
-        <a href="https:&#x2F;&#x2F;novemberkilo.com">The iNK blot</a>
+        <a href="https://thiago4go.github.io">The iNK blot</a>
       </div>
       <nav class="site-nav hide-in-mobile">
         
@@ -44,14 +44,14 @@
       <span class="hdr-social hide-in-mobile">
         
 
-<a href="https:&#x2F;&#x2F;www.linkedin.com&#x2F;in&#x2F;novemberkilo" target="_blank" rel="noopener me"
+<a href="https:&#x2F;&#x2F;www.linkedin.com&#x2F;in&#x2F;thiago4go" target="_blank" rel="noopener me"
    title="linkedin">
   
   <svg xmlns="http://www.w3.org/2000/svg" class="feather" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
   
 </a>
 
-<a href="https:&#x2F;&#x2F;github.com&#x2F;novemberkilo" target="_blank" rel="noopener me"
+<a href="https:&#x2F;&#x2F;github.com&#x2F;thiago4go" target="_blank" rel="noopener me"
    title="github">
   
   <svg xmlns="http://www.w3.org/2000/svg" class="feather" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
@@ -103,7 +103,7 @@
     <ul class="posts-list">
       
       <li class="post-item">
-        <a href="https:&#x2F;&#x2F;novemberkilo.com&#x2F;posts&#x2F;refactoring-with-applicative&#x2F;">
+        <a href="https://thiago4go.github.io&#x2F;posts&#x2F;refactoring-with-applicative&#x2F;">
           <span class="post-title">Refactoring with Applicative - a small example in Haskell</span>
           <span class="post-day"
             >Jan 27</span
@@ -122,7 +122,7 @@
 	   
 
 <footer id="site-footer" class="section-inner thin animated fadeIn faster">
-  <p>&copy; 2022 <a href="https:&#x2F;&#x2F;novemberkilo.com">novemberkilo</a> &#183; <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">CC BY 4.0</a></p>
+  <p>&copy; 2022 <a href="https://thiago4go.github.io">thiago4go</a> &#183; <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">CC BY 4.0</a></p>
   <p>Made with <a href="https://www.getzola.org" target="_blank" rel="noopener">Zola</a> &#183; Theme <a href="https://github.com/VersBinarii/hermit_zola" target="_blank" rel="noopener">Hermit_Zola</a>
 	
   </p>
@@ -131,7 +131,7 @@
  
 	</div>
 	
-	<script src="https://novemberkilo.com/js/main.js"></script>
+	<script src="https://thiago4go.github.io/js/main.js"></script>
 
 	<!-- Math rendering -->
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">

--- a/tags/blog/rss.xml
+++ b/tags/blog/rss.xml
@@ -2,17 +2,17 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
       <title>The iNK blot - blog</title>
-        <link>https://novemberkilo.com</link>
+        <link>https://thiago4go.github.io</link>
         <description></description>
         <generator>Zola</generator>
         <language>en</language>
-        <atom:link href="https://novemberkilo.com/tags/blog/rss.xml" rel="self" type="application/rss+xml"/>
+        <atom:link href="https://thiago4go.github.io/tags/blog/rss.xml" rel="self" type="application/rss+xml"/>
         <lastBuildDate>Sun, 27 May 2018 00:00:00 +0000</lastBuildDate>
         <item>
             <title>Refactoring with Applicative - a small example in Haskell</title>
             <pubDate>Sun, 27 May 2018 00:00:00 +0000</pubDate>
-            <link>https://novemberkilo.com/posts/refactoring-with-applicative/</link>
-            <guid>https://novemberkilo.com/posts/refactoring-with-applicative/</guid>
+            <link>https://thiago4go.github.io/posts/refactoring-with-applicative/</link>
+            <guid>https://thiago4go.github.io/posts/refactoring-with-applicative/</guid>
             <description>&lt;p&gt;Recently I came across a neat little refactoring example that I thought
 might prove useful, particularly to those starting out with Haskell.&lt;&#x2F;p&gt;
 &lt;h4 id=&quot;setting-the-scene&quot;&gt;Setting the scene&lt;&#x2F;h4&gt;

--- a/tags/haskell/index.html
+++ b/tags/haskell/index.html
@@ -6,21 +6,21 @@
   <meta itemprop="name" content="The iNK blot" />
   <meta itemprop="description" content="" />
 
-  <link rel="apple-touch-icon" sizes="180x180" href="https://novemberkilo.com/apple-touch-icon.png"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="https://novemberkilo.com/favicon-32x32.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://thiago4go.github.io/apple-touch-icon.png"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="https://thiago4go.github.io/favicon-32x32.png" />
   <link
     rel="icon"
     type="image/png"
     sizes="16x16"
-    href="https://novemberkilo.com/favicon-16x16.png"
+    href="https://thiago4go.github.io/favicon-16x16.png"
   />
   <link
     rel="shortcut icon"
-    href="https://novemberkilo.com/favicon.ico"
+    href="https://thiago4go.github.io/favicon.ico"
   />
   <link rel="stylesheet"
     href="https://fonts.googleapis.com/css?family=Inter">
-  <link rel="stylesheet" href="https://novemberkilo.com/style.css"/>
+  <link rel="stylesheet" href="https://thiago4go.github.io/style.css"/>
   <title>The iNK blot</title>
 
   <body id="page">
@@ -30,7 +30,7 @@
   <div class="hdr-wrapper section-inner">
     <div class="hdr-left">
       <div class="site-branding">
-        <a href="https:&#x2F;&#x2F;novemberkilo.com">The iNK blot</a>
+        <a href="https://thiago4go.github.io">The iNK blot</a>
       </div>
       <nav class="site-nav hide-in-mobile">
         
@@ -44,14 +44,14 @@
       <span class="hdr-social hide-in-mobile">
         
 
-<a href="https:&#x2F;&#x2F;www.linkedin.com&#x2F;in&#x2F;novemberkilo" target="_blank" rel="noopener me"
+<a href="https:&#x2F;&#x2F;www.linkedin.com&#x2F;in&#x2F;thiago4go" target="_blank" rel="noopener me"
    title="linkedin">
   
   <svg xmlns="http://www.w3.org/2000/svg" class="feather" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
   
 </a>
 
-<a href="https:&#x2F;&#x2F;github.com&#x2F;novemberkilo" target="_blank" rel="noopener me"
+<a href="https:&#x2F;&#x2F;github.com&#x2F;thiago4go" target="_blank" rel="noopener me"
    title="github">
   
   <svg xmlns="http://www.w3.org/2000/svg" class="feather" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
@@ -103,7 +103,7 @@
     <ul class="posts-list">
       
       <li class="post-item">
-        <a href="https:&#x2F;&#x2F;novemberkilo.com&#x2F;posts&#x2F;refactoring-with-applicative&#x2F;">
+        <a href="https://thiago4go.github.io&#x2F;posts&#x2F;refactoring-with-applicative&#x2F;">
           <span class="post-title">Refactoring with Applicative - a small example in Haskell</span>
           <span class="post-day"
             >Jan 27</span
@@ -122,7 +122,7 @@
 	   
 
 <footer id="site-footer" class="section-inner thin animated fadeIn faster">
-  <p>&copy; 2022 <a href="https:&#x2F;&#x2F;novemberkilo.com">novemberkilo</a> &#183; <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">CC BY 4.0</a></p>
+  <p>&copy; 2022 <a href="https://thiago4go.github.io">thiago4go</a> &#183; <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">CC BY 4.0</a></p>
   <p>Made with <a href="https://www.getzola.org" target="_blank" rel="noopener">Zola</a> &#183; Theme <a href="https://github.com/VersBinarii/hermit_zola" target="_blank" rel="noopener">Hermit_Zola</a>
 	
   </p>
@@ -131,7 +131,7 @@
  
 	</div>
 	
-	<script src="https://novemberkilo.com/js/main.js"></script>
+	<script src="https://thiago4go.github.io/js/main.js"></script>
 
 	<!-- Math rendering -->
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">

--- a/tags/haskell/rss.xml
+++ b/tags/haskell/rss.xml
@@ -2,17 +2,17 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
       <title>The iNK blot - haskell</title>
-        <link>https://novemberkilo.com</link>
+        <link>https://thiago4go.github.io</link>
         <description></description>
         <generator>Zola</generator>
         <language>en</language>
-        <atom:link href="https://novemberkilo.com/tags/haskell/rss.xml" rel="self" type="application/rss+xml"/>
+        <atom:link href="https://thiago4go.github.io/tags/haskell/rss.xml" rel="self" type="application/rss+xml"/>
         <lastBuildDate>Sun, 27 May 2018 00:00:00 +0000</lastBuildDate>
         <item>
             <title>Refactoring with Applicative - a small example in Haskell</title>
             <pubDate>Sun, 27 May 2018 00:00:00 +0000</pubDate>
-            <link>https://novemberkilo.com/posts/refactoring-with-applicative/</link>
-            <guid>https://novemberkilo.com/posts/refactoring-with-applicative/</guid>
+            <link>https://thiago4go.github.io/posts/refactoring-with-applicative/</link>
+            <guid>https://thiago4go.github.io/posts/refactoring-with-applicative/</guid>
             <description>&lt;p&gt;Recently I came across a neat little refactoring example that I thought
 might prove useful, particularly to those starting out with Haskell.&lt;&#x2F;p&gt;
 &lt;h4 id=&quot;setting-the-scene&quot;&gt;Setting the scene&lt;&#x2F;h4&gt;

--- a/tags/index.html
+++ b/tags/index.html
@@ -6,21 +6,21 @@
   <meta itemprop="name" content="The iNK blot" />
   <meta itemprop="description" content="" />
 
-  <link rel="apple-touch-icon" sizes="180x180" href="https://novemberkilo.com/apple-touch-icon.png"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="https://novemberkilo.com/favicon-32x32.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://thiago4go.github.io/apple-touch-icon.png"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="https://thiago4go.github.io/favicon-32x32.png" />
   <link
     rel="icon"
     type="image/png"
     sizes="16x16"
-    href="https://novemberkilo.com/favicon-16x16.png"
+    href="https://thiago4go.github.io/favicon-16x16.png"
   />
   <link
     rel="shortcut icon"
-    href="https://novemberkilo.com/favicon.ico"
+    href="https://thiago4go.github.io/favicon.ico"
   />
   <link rel="stylesheet"
     href="https://fonts.googleapis.com/css?family=Inter">
-  <link rel="stylesheet" href="https://novemberkilo.com/style.css"/>
+  <link rel="stylesheet" href="https://thiago4go.github.io/style.css"/>
   <title>The iNK blot</title>
 
   <body id="page">
@@ -30,7 +30,7 @@
   <div class="hdr-wrapper section-inner">
     <div class="hdr-left">
       <div class="site-branding">
-        <a href="https:&#x2F;&#x2F;novemberkilo.com">The iNK blot</a>
+        <a href="https://thiago4go.github.io">The iNK blot</a>
       </div>
       <nav class="site-nav hide-in-mobile">
         
@@ -44,14 +44,14 @@
       <span class="hdr-social hide-in-mobile">
         
 
-<a href="https:&#x2F;&#x2F;www.linkedin.com&#x2F;in&#x2F;novemberkilo" target="_blank" rel="noopener me"
+<a href="https:&#x2F;&#x2F;www.linkedin.com&#x2F;in&#x2F;thiago4go" target="_blank" rel="noopener me"
    title="linkedin">
   
   <svg xmlns="http://www.w3.org/2000/svg" class="feather" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
   
 </a>
 
-<a href="https:&#x2F;&#x2F;github.com&#x2F;novemberkilo" target="_blank" rel="noopener me"
+<a href="https:&#x2F;&#x2F;github.com&#x2F;thiago4go" target="_blank" rel="noopener me"
    title="github">
   
   <svg xmlns="http://www.w3.org/2000/svg" class="feather" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
@@ -119,7 +119,7 @@
 	   
 
 <footer id="site-footer" class="section-inner thin animated fadeIn faster">
-  <p>&copy; 2022 <a href="https:&#x2F;&#x2F;novemberkilo.com">novemberkilo</a> &#183; <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">CC BY 4.0</a></p>
+  <p>&copy; 2022 <a href="https://thiago4go.github.io">thiago4go</a> &#183; <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">CC BY 4.0</a></p>
   <p>Made with <a href="https://www.getzola.org" target="_blank" rel="noopener">Zola</a> &#183; Theme <a href="https://github.com/VersBinarii/hermit_zola" target="_blank" rel="noopener">Hermit_Zola</a>
 	
   </p>
@@ -128,7 +128,7 @@
  
 	</div>
 	
-	<script src="https://novemberkilo.com/js/main.js"></script>
+	<script src="https://thiago4go.github.io/js/main.js"></script>
 
 	<!-- Math rendering -->
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">

--- a/tags/refactoring/index.html
+++ b/tags/refactoring/index.html
@@ -6,21 +6,21 @@
   <meta itemprop="name" content="The iNK blot" />
   <meta itemprop="description" content="" />
 
-  <link rel="apple-touch-icon" sizes="180x180" href="https://novemberkilo.com/apple-touch-icon.png"/>
-  <link rel="icon" type="image/png" sizes="32x32" href="https://novemberkilo.com/favicon-32x32.png" />
+  <link rel="apple-touch-icon" sizes="180x180" href="https://thiago4go.github.io/apple-touch-icon.png"/>
+  <link rel="icon" type="image/png" sizes="32x32" href="https://thiago4go.github.io/favicon-32x32.png" />
   <link
     rel="icon"
     type="image/png"
     sizes="16x16"
-    href="https://novemberkilo.com/favicon-16x16.png"
+    href="https://thiago4go.github.io/favicon-16x16.png"
   />
   <link
     rel="shortcut icon"
-    href="https://novemberkilo.com/favicon.ico"
+    href="https://thiago4go.github.io/favicon.ico"
   />
   <link rel="stylesheet"
     href="https://fonts.googleapis.com/css?family=Inter">
-  <link rel="stylesheet" href="https://novemberkilo.com/style.css"/>
+  <link rel="stylesheet" href="https://thiago4go.github.io/style.css"/>
   <title>The iNK blot</title>
 
   <body id="page">
@@ -30,7 +30,7 @@
   <div class="hdr-wrapper section-inner">
     <div class="hdr-left">
       <div class="site-branding">
-        <a href="https:&#x2F;&#x2F;novemberkilo.com">The iNK blot</a>
+        <a href="https://thiago4go.github.io">The iNK blot</a>
       </div>
       <nav class="site-nav hide-in-mobile">
         
@@ -44,14 +44,14 @@
       <span class="hdr-social hide-in-mobile">
         
 
-<a href="https:&#x2F;&#x2F;www.linkedin.com&#x2F;in&#x2F;novemberkilo" target="_blank" rel="noopener me"
+<a href="https:&#x2F;&#x2F;www.linkedin.com&#x2F;in&#x2F;thiago4go" target="_blank" rel="noopener me"
    title="linkedin">
   
   <svg xmlns="http://www.w3.org/2000/svg" class="feather" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-2-2 2 2 0 0 0-2 2v7h-4v-7a6 6 0 0 1 6-6z"></path><rect x="2" y="9" width="4" height="12"></rect><circle cx="4" cy="4" r="2"></circle></svg>
   
 </a>
 
-<a href="https:&#x2F;&#x2F;github.com&#x2F;novemberkilo" target="_blank" rel="noopener me"
+<a href="https:&#x2F;&#x2F;github.com&#x2F;thiago4go" target="_blank" rel="noopener me"
    title="github">
   
   <svg xmlns="http://www.w3.org/2000/svg" class="feather" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"></path></svg>
@@ -103,7 +103,7 @@
     <ul class="posts-list">
       
       <li class="post-item">
-        <a href="https:&#x2F;&#x2F;novemberkilo.com&#x2F;posts&#x2F;refactoring-with-applicative&#x2F;">
+        <a href="https://thiago4go.github.io&#x2F;posts&#x2F;refactoring-with-applicative&#x2F;">
           <span class="post-title">Refactoring with Applicative - a small example in Haskell</span>
           <span class="post-day"
             >Jan 27</span
@@ -122,7 +122,7 @@
 	   
 
 <footer id="site-footer" class="section-inner thin animated fadeIn faster">
-  <p>&copy; 2022 <a href="https:&#x2F;&#x2F;novemberkilo.com">novemberkilo</a> &#183; <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">CC BY 4.0</a></p>
+  <p>&copy; 2022 <a href="https://thiago4go.github.io">thiago4go</a> &#183; <a href="https://creativecommons.org/licenses/by/4.0/" target="_blank" rel="noopener">CC BY 4.0</a></p>
   <p>Made with <a href="https://www.getzola.org" target="_blank" rel="noopener">Zola</a> &#183; Theme <a href="https://github.com/VersBinarii/hermit_zola" target="_blank" rel="noopener">Hermit_Zola</a>
 	
   </p>
@@ -131,7 +131,7 @@
  
 	</div>
 	
-	<script src="https://novemberkilo.com/js/main.js"></script>
+	<script src="https://thiago4go.github.io/js/main.js"></script>
 
 	<!-- Math rendering -->
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.11.1/dist/katex.min.css" integrity="sha384-zB1R0rpPzHqg7Kpt0Aljp8JPLqbXI3bhnPWROx27a9N0Ll6ZP/+DiW/UqRcLbRjq" crossorigin="anonymous">

--- a/tags/refactoring/rss.xml
+++ b/tags/refactoring/rss.xml
@@ -2,17 +2,17 @@
 <rss xmlns:atom="http://www.w3.org/2005/Atom" version="2.0">
     <channel>
       <title>The iNK blot - refactoring</title>
-        <link>https://novemberkilo.com</link>
+        <link>https://thiago4go.github.io</link>
         <description></description>
         <generator>Zola</generator>
         <language>en</language>
-        <atom:link href="https://novemberkilo.com/tags/refactoring/rss.xml" rel="self" type="application/rss+xml"/>
+        <atom:link href="https://thiago4go.github.io/tags/refactoring/rss.xml" rel="self" type="application/rss+xml"/>
         <lastBuildDate>Sun, 27 May 2018 00:00:00 +0000</lastBuildDate>
         <item>
             <title>Refactoring with Applicative - a small example in Haskell</title>
             <pubDate>Sun, 27 May 2018 00:00:00 +0000</pubDate>
-            <link>https://novemberkilo.com/posts/refactoring-with-applicative/</link>
-            <guid>https://novemberkilo.com/posts/refactoring-with-applicative/</guid>
+            <link>https://thiago4go.github.io/posts/refactoring-with-applicative/</link>
+            <guid>https://thiago4go.github.io/posts/refactoring-with-applicative/</guid>
             <description>&lt;p&gt;Recently I came across a neat little refactoring example that I thought
 might prove useful, particularly to those starting out with Haskell.&lt;&#x2F;p&gt;
 &lt;h4 id=&quot;setting-the-scene&quot;&gt;Setting the scene&lt;&#x2F;h4&gt;


### PR DESCRIPTION
## Summary
- Replace novemberkilo.com URLs with https://thiago4go.github.io
- Update tag pages, RSS feeds, and footer links to new domain and social handles
- Point robots.txt and sitemap.xml to thiago4go.github.io

## Testing
- `rg novemberkilo` (no results)
- `python3 -m http.server` & `curl -s http://localhost:8000/tags/index.html | head -n 20`
- `curl -s http://localhost:8000/robots.txt`
- `curl -s http://localhost:8000/sitemap.xml | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68ad28a8151c83219bd4bd743944f9d5