### PR TITLE
feat: add optional navigation fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,19 @@
 # thiago4go.github.io
 my blog
+
+## Post Generator
+
+The `post-generator` folder contains a script that builds new blog posts from
+`content.json` and `blog_template.html`. Along with the existing content fields,
+the script accepts optional navigation fields:
+
+- `OLDER_POST_LINK` – URL of the previous post
+- `OLDER_POST_TITLE` – Title of the previous post
+- `NEWER_POST_LINK` – URL of the next post
+- `NEWER_POST_TITLE` – Title of the next post
+
+Include these keys in `content.json` when you want navigation links populated.
+If they are omitted, empty strings are used.
+
+See `post-generator/content template.json` for a sample configuration.
+

--- a/post-generator/content.json
+++ b/post-generator/content.json
@@ -8,8 +8,8 @@
     "POST_CONCLUSION": "Learning is an ongoing journey, and embracing it can lead to amazing transformations.",
     "POST_TAGS": "Ongoing Education | Personal Growth | Continuous Learning",
     "POST_WORD_COUNT": "477",
-    "OLDER_POST_LINK": "",
-    "OLDER_POST_TITLE": "",
-    "NEWER_POST_LINK": "",
-    "NEWER_POST_TITLE": ""
+    "OLDER_POST_LINK": "/posts/older-post",
+    "OLDER_POST_TITLE": "Previous Post",
+    "NEWER_POST_LINK": "/posts/newer-post",
+    "NEWER_POST_TITLE": "Next Post"
 }

--- a/post-generator/post-generator.py
+++ b/post-generator/post-generator.py
@@ -22,9 +22,12 @@ placeholder_values = {
     "{{POST_CONTENT}}": config["POST_CONTENT"],
     "{{POST_CONCLUSION}}": config["POST_CONCLUSION"],
     "{{POST_TAGS}}": config["POST_TAGS"],
-    "{{POST_WORD_COUNT}}": config["POST_WORD_COUNT"]
+    "{{POST_WORD_COUNT}}": config["POST_WORD_COUNT"],
+    "{{OLDER_POST_LINK}}": config.get("OLDER_POST_LINK", ""),
+    "{{OLDER_POST_TITLE}}": config.get("OLDER_POST_TITLE", ""),
+    "{{NEWER_POST_LINK}}": config.get("NEWER_POST_LINK", ""),
+    "{{NEWER_POST_TITLE}}": config.get("NEWER_POST_TITLE", "")
 }
-
 
 # Read the template content
 with open(TEMPLATE_FILE_PATH, 'r') as file:


### PR DESCRIPTION
## Summary
- allow post generator to handle optional newer and older post navigation fields
- extend sample content and template with navigation metadata
- document new navigation keys in README

## Testing
- `python post-generator/post-generator.py`


------
https://chatgpt.com/codex/tasks/task_e_68ad2b5179c8832186d8b26b8baab311